### PR TITLE
Update before release

### DIFF
--- a/example/TriangleSurfaceCutting_FanForceField.scn
+++ b/example/TriangleSurfaceCutting_FanForceField.scn
@@ -6,48 +6,42 @@
     <VisualStyle displayFlags="showVisual showBehaviorModels" />
 
     <!-- Specify the dependency to our plugin "MyAwesomeComponents" -->
-    <AddPluginRepository path="/data/Softwares/SOFA_Releases/MyAwesomeComponents/build" /> <!-- Make sure to CHANGE THIS PATH with your own -->
+    <!-- <AddPluginRepository path="/data/Softwares/SOFA_Releases/MyAwesomeComponents/build" /> --> <!-- Make sure to CHANGE THIS PATH with your own -->
     <RequiredPlugin pluginName="MyAwesomeComponents" />
 
     <!-- Specify all dependencies on SOFA modules -->
     <Node name="PluginLoaded" >
-        <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase,BruteForceBroadPhase,CollisionPipeline] -->  
-        <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->  
-        <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->  
-        <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->  
-        <RequiredPlugin name="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader] -->  
-        <RequiredPlugin name="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->  
-        <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->  
-        <RequiredPlugin name="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass] -->  
-        <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->  
-        <RequiredPlugin name="Sofa.Component.SceneUtility"/> <!-- Needed to use components [AddPluginRepository] -->  
-        <RequiredPlugin name="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TriangularFEMForceField] -->  
-        <RequiredPlugin name="Sofa.Component.SolidMechanics.Spring"/> <!-- Needed to use components [TriangularBendingSprings] -->  
-        <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->  
-        <RequiredPlugin name="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TriangleSetGeometryAlgorithms,TriangleSetTopologyContainer,TriangleSetTopologyModifier] -->  
-        <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
-        <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->  
+        <RequiredPlugin pluginName="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase,BruteForceBroadPhase,CollisionPipeline] -->  
+        <RequiredPlugin pluginName="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->  
+        <RequiredPlugin pluginName="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [DefaultContactManager] -->  
+        <RequiredPlugin pluginName="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedConstraint] -->  
+        <RequiredPlugin pluginName="Sofa.Component.IO.Mesh"/> <!-- Needed to use components [MeshGmshLoader] -->  
+        <RequiredPlugin pluginName="Sofa.Component.LinearSolver.Iterative"/> <!-- Needed to use components [CGLinearSolver] -->  
+        <RequiredPlugin pluginName="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [IdentityMapping] -->  
+        <RequiredPlugin pluginName="Sofa.Component.Mass"/> <!-- Needed to use components [DiagonalMass] -->  
+        <RequiredPlugin pluginName="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->  
+        <RequiredPlugin pluginName="Sofa.Component.SceneUtility"/> <!-- Needed to use components [AddPluginRepository] -->  
+        <RequiredPlugin pluginName="Sofa.Component.SolidMechanics.FEM.Elastic"/> <!-- Needed to use components [TriangularFEMForceField] -->  
+        <RequiredPlugin pluginName="Sofa.Component.SolidMechanics.Spring"/> <!-- Needed to use components [TriangularBendingSprings] -->  
+        <RequiredPlugin pluginName="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->  
+        <RequiredPlugin pluginName="Sofa.Component.Topology.Container.Dynamic"/> <!-- Needed to use components [TriangleSetGeometryAlgorithms,TriangleSetTopologyContainer,TriangleSetTopologyModifier] -->  
+        <RequiredPlugin pluginName="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
+        <RequiredPlugin pluginName="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->  
 
     </Node>
 
     <DefaultAnimationLoop name="SceneAnimationLoop" />
 
-    <CollisionPipeline verbose="0" />
-    <BruteForceBroadPhase/>
-    <BVHNarrowPhase/>
-    <CollisionResponse response="PenalityContactForceField" />
-    <MinProximityIntersection name="Proximity" alarmDistance="0.8" contactDistance="0.5" />
-
     <Node name="SquareGravity">
         <EulerImplicitSolver name="cg_odesolver" printLog="false" />
-        <CGLinearSolver iterations="25" name="linear solver" tolerance="1.0e-9" threshold="1.0e-9" />
+        <CGLinearSolver iterations="25" name="linear_solver" tolerance="1.0e-9" threshold="1.0e-9" />
         <MeshGmshLoader name="meshLoader" filename="mesh/square3.msh" scale="10" createSubelements="true" />
         <include href="Objects/TriangleSetTopology.xml" src="@meshLoader" />
         <MechanicalObject name="MechanicalModel" template="Vec3d"/>
         <DiagonalMass massDensity="0.15" />
         <FixedProjectiveConstraint indices="0 1" />
         <TriangularFEMForceField name="FEM" youngModulus="60" poissonRatio="0.3" method="large" />
-        <TriangularBendingSprings name="FEM-Bend" stiffness="300" damping="1.0" />
+        <TriangularBendingSprings name="FEM_bending" stiffness="300" damping="1.0" />
 
         <!-- ForceField implemented in the plugin -->
         <FanForceField force="0 0 0.05" randForceMinCoeff="0" randForceMaxCoeff="1" randForceCoeffChangeProba="0.10" /> 

--- a/src/MyAwesomeComponents/FanForceField.cpp
+++ b/src/MyAwesomeComponents/FanForceField.cpp
@@ -28,20 +28,16 @@
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/defaulttype/RigidTypes.h>
 
-namespace sofa::component::mechanicalload
-{
-
-template class MYAWESOMECOMPONENTS_API sofa::component::mechanicalload::FanForceField<sofa::defaulttype::Vec3Types>;
-
-} // sofa::component::mechanicalload
-
-
 namespace myawesomecomponents
 {
+
+
 void registerFanForceField(sofa::core::ObjectFactory* factory)
 {
     factory->registerObjects(sofa::core::ObjectRegistrationData("Random forces applied to all mesh nodes")
-                             .add< sofa::component::mechanicalload::FanForceField<sofa::defaulttype::Vec3Types> >());
+                             .add< FanForceField<sofa::defaulttype::Vec3Types> >());
 }
+
+template class MYAWESOMECOMPONENTS_API FanForceField<sofa::defaulttype::Vec3Types>;
 
 } // myawesomecomponents

--- a/src/MyAwesomeComponents/FanForceField.h
+++ b/src/MyAwesomeComponents/FanForceField.h
@@ -29,25 +29,25 @@
 #include <sofa/core/topology/BaseMeshTopology.h>
 
 
-namespace sofa::component::mechanicalload
+namespace myawesomecomponents
 {
 
 template<class DataTypes>
-class FanForceField : public core::behavior::ForceField<DataTypes>
+class FanForceField : public sofa::core::behavior::ForceField<DataTypes>
 {
 public:
-    SOFA_CLASS(SOFA_TEMPLATE(FanForceField, DataTypes), SOFA_TEMPLATE(core::behavior::ForceField, DataTypes));
+    SOFA_CLASS(SOFA_TEMPLATE(FanForceField, DataTypes), SOFA_TEMPLATE(sofa::core::behavior::ForceField, DataTypes));
 
-    typedef core::behavior::ForceField<DataTypes> Inherit;
+    typedef sofa::core::behavior::ForceField<DataTypes> Inherit;
     typedef typename DataTypes::Deriv Deriv;
     typedef typename DataTypes::VecCoord VecCoord;
     typedef typename DataTypes::VecDeriv VecDeriv;
-    typedef core::objectmodel::Data<VecCoord> DataVecCoord;
-    typedef core::objectmodel::Data<VecDeriv> DataVecDeriv;
+    typedef sofa::core::objectmodel::Data<VecCoord> DataVecCoord;
+    typedef sofa::core::objectmodel::Data<VecDeriv> DataVecDeriv;
 
 public:
     /// Force applied at each point
-    Data< Deriv > d_force;
+    sofa::core::objectmodel::Data< Deriv > d_force;
 
 protected:    
     /// Component constructor
@@ -60,21 +60,21 @@ public:
     void init() override;
 
     /// Forces addition for explicit and implicit integration schemes
-    virtual void addForce (const core::MechanicalParams* params, DataVecDeriv& currentForce, const DataVecCoord& currentPosition, const DataVecDeriv& currentVelocities) override;
+    virtual void addForce (const sofa::core::MechanicalParams* params, DataVecDeriv& currentForce, const DataVecCoord& currentPosition, const DataVecDeriv& currentVelocities) override;
 
     /// Forces addition for implicit integration schemes
-    virtual void addDForce(const core::MechanicalParams* /*mparams*/, DataVecDeriv& /*d_df*/ , const DataVecDeriv& /*d_dx*/) override {}
+    virtual void addDForce(const sofa::core::MechanicalParams* /*mparams*/, DataVecDeriv& /*d_df*/ , const DataVecDeriv& /*d_dx*/) override {}
 
-    virtual SReal getPotentialEnergy(const core::MechanicalParams* /*params*/, const DataVecCoord& /*x*/) const override { return 0; } // Keep it simple
+    virtual SReal getPotentialEnergy(const sofa::core::MechanicalParams* /*params*/, const DataVecCoord& /*x*/) const override { return 0; } // Keep it simple
 
 public:
 
     /// Range for random force coefficient : [randForceMin ; randForceMax]
-    Data<float> d_randForceMinCoeff;
-    Data<float> d_randForceMaxCoeff;
+    sofa::core::objectmodel::Data<float> d_randForceMinCoeff;
+    sofa::core::objectmodel::Data<float> d_randForceMaxCoeff;
 
     /// Probability to change random force coefficient
-    Data<float> d_randForceCoeffChangeProba;
+    sofa::core::objectmodel::   Data<float> d_randForceCoeffChangeProba;
 
 protected:
     /// Used to get random numbers
@@ -90,5 +90,5 @@ protected:
 extern template class MYAWESOMECOMPONENTS_API FanForceField<sofa::defaulttype::Vec3Types>;
 #endif
 
-} // namespace sofa::component::mechanicalload
+} // namespace myawesomecomponents
 

--- a/src/MyAwesomeComponents/FanForceField.inl
+++ b/src/MyAwesomeComponents/FanForceField.inl
@@ -23,7 +23,7 @@
 
 #include <MyAwesomeComponents/FanForceField.h>
 
-namespace sofa::component::mechanicalload
+namespace myawesomecomponents
 {
 
 template<class DataTypes>
@@ -50,7 +50,7 @@ void FanForceField<DataTypes>::init()
 
 
 template<class DataTypes>
-void FanForceField<DataTypes>::addForce(const core::MechanicalParams* /*params*/, DataVecDeriv& currentForce, const DataVecCoord& /*currentPosition*/, const DataVecDeriv& /*currentVelocities*/)
+void FanForceField<DataTypes>::addForce(const sofa::core::MechanicalParams* /*params*/, DataVecDeriv& currentForce, const DataVecCoord& /*currentPosition*/, const DataVecDeriv& /*currentVelocities*/)
 {
     float randProba = m_randomGenerator.random<float>(0, 1);
     if( randProba < d_randForceCoeffChangeProba.getValue() )
@@ -58,12 +58,12 @@ void FanForceField<DataTypes>::addForce(const core::MechanicalParams* /*params*/
         m_randForceCoeff = m_randomGenerator.random<float>(d_randForceMinCoeff.getValue(), d_randForceMaxCoeff.getValue()); // generating new random force coefficient
     }
 
-    sofa::helper::WriteAccessor<core::objectmodel::Data< VecDeriv> > force = currentForce; // create writer on the current force
+    sofa::helper::WriteAccessor<sofa::core::objectmodel::Data< VecDeriv> > force = currentForce; // create writer on the current force
     for(sofa::Size i = 0 ; i < m_topology->getNbPoints() ; i++)
     {
         force[i] += d_force.getValue() * m_randForceCoeff; // Add asked force randomized with coeff
     }
 }
 
-} // namespace sofa::component::mechanicalload
+} // namespace myawesomecomponents
 

--- a/src/MyAwesomeComponents/initMyAwesomeComponents.cpp
+++ b/src/MyAwesomeComponents/initMyAwesomeComponents.cpp
@@ -26,12 +26,19 @@
 
 namespace myawesomecomponents
 {
-
 extern void registerFanForceField(sofa::core::ObjectFactory* factory);
 
-extern "C" {
 
-MYAWESOMECOMPONENTS_API
+extern "C" {
+    MYAWESOMECOMPONENTS_API void initExternalModule();
+    MYAWESOMECOMPONENTS_API const char* getModuleName();
+    MYAWESOMECOMPONENTS_API const char* getModuleVersion();
+    MYAWESOMECOMPONENTS_API const char* getModuleLicense();
+    MYAWESOMECOMPONENTS_API const char* getModuleDescription();
+    MYAWESOMECOMPONENTS_API void registerObjects(sofa::core::ObjectFactory* factory);
+}
+
+
 void initExternalModule()
 {
     static bool first = true;
@@ -44,44 +51,43 @@ void initExternalModule()
     }
 }
 
-MYAWESOMECOMPONENTS_API
+
 const char* getModuleName()
 {
     return MODULE_NAME;
 }
 
-MYAWESOMECOMPONENTS_API
+
 const char* getModuleVersion()
 {
     return MODULE_VERSION;
 }
 
-MYAWESOMECOMPONENTS_API
+
 const char* getModuleLicense()
 {
     return "LGPL";
 }
 
-MYAWESOMECOMPONENTS_API
+
 const char* getModuleDescription()
 {
     return "SOFA plugin example";
 }
 
-MYAWESOMECOMPONENTS_API
+
 const char* getModuleComponentList()
 {
     // string containing the names of the classes provided by the plugin
     return "FanForceField";
 }
 
-MYAWESOMECOMPONENTS_API
+
 void registerObjects(sofa::core::ObjectFactory* factory)
 {
     registerFanForceField(factory);
 }
 
 
-} // extern "C"
 
 } // namespace myawesomecomponents


### PR DESCRIPTION
Still having the error when loading the plugin : 

```
It could be because: 
 
the entrypoint registerObjects() has not been implemented;
(deprecated since v24.12) no sofa::core::RegisterObject() has been called;
your plugin does not add any component (i.e BaseObject) into the factory. In that case, RequiredPlugin is not useful for this kind of plugin.
```

The rest works nicely